### PR TITLE
windows fixes

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -9,6 +9,8 @@ if (PHP_RIAK != "no") {
                 ADD_SOURCES(configure_module_dirname + "/riack/src", "riack_sock.c riack.c riack_kv.c riack_search.c riack_msg.c riack_mem.c riack_helpers.c", "riak");
                 ADD_SOURCES(configure_module_dirname + "/riack/src/google/protobuf-c", "protobuf-c.c", "riak");
                 ADD_SOURCES(configure_module_dirname + "/riack/src/protocol", "riak_msg_codes.c riak_search.pb-c.c riak.pb-c.c riak_kv.pb-c.c", "riak");
+
+		ADD_FLAG("CFLAGS_RIAK", "/D riack_EXPORTS");
 		AC_DEFINE('HAVE_RIAK', 1);
 		ADD_EXTENSION_DEP('riak', 'json');
 		ADD_EXTENSION_DEP('riak', 'session');

--- a/riak_session.c
+++ b/riak_session.c
@@ -49,6 +49,13 @@
         zend_update_property(riak_delete_input_ce, CLIENT, NAME, sizeof(NAME)-1, *ZPP TSRMLS_CC); \
     }
 
+PS_OPEN_FUNC(riak);
+PS_CLOSE_FUNC(riak);
+PS_READ_FUNC(riak);
+PS_WRITE_FUNC(riak);
+PS_DESTROY_FUNC(riak);
+PS_GC_FUNC(riak);
+
 ps_module ps_mod_riak = {
 	PS_MOD(riak)
 };


### PR DESCRIPTION
Please consider to put the riack lib into the PECL tgz, otherwise the build will always fail, on Windows at least. Also please be sure applying the following to the riak lib

$ diff -ru riack.orig riack
Only in riack.orig: .git
diff -ru riack.orig/src/ints.h riack/src/ints.h
--- riack.orig/src/ints.h       Sun Sep 15 01:20:33 2013
+++ riack/src/ints.h    Sun Sep 15 01:22:25 2013
@@ -5,7 +5,7 @@
 #include "riack-config.h"
 #endif

-#if defined(HAVE_STDINT_H)
+#if defined(HAVE_STDINT_H) && !defined(_WIN32)
 #include <stdint.h>
 #else
 #define int32_t      signed __int32
diff -ru riack.orig/src/riack.c riack/src/riack.c
--- riack.orig/src/riack.c      Sun Sep 15 01:20:33 2013
+++ riack/src/riack.c   Sun Sep 15 01:16:17 2013
@@ -461,9 +461,10 @@
 struct RIACK_COMMIT_HOOK\* riack_rpb_hooks_to_hooks(struct RIACK_CLIENT _client, RpbCommitHook *_ rpb_hooks, size_t hook_count)
 {
     size_t i;
-   struct RIACK_COMMIT_HOOK\* result;
   if (hook_count == 0) return 0;
-    struct RIACK_COMMIT_HOOK\* result = RCALLOC(client, sizeof(struct RIACK_COMMIT_HOOK*) \* hook_count);
-    result = RCALLOC(client, sizeof(struct RIACK_COMMIT_HOOK*) \* hook_count);
   for (i=0; i<hook_count; ++i) {
       if (rpb_hooks[i]->has_name) {
           RMALLOCCOPY(client, result[i].name.value, result[i].name.len, rpb_hooks[i]->name.data, rpb_hooks[i]->name.len);

You might also consider to PR this patch to the upstream. 

With this fixes I currently could build the last riak ext release on windows and it built just fine. You should have some mail about those builds in your mailbox, if no - look under http://windows.php.net/downloads/pecl/releases/riak/0.5.1/ . Please note that you'll probably need to fix some of the protobuf stuff on Windows x64 (see the build logs).
